### PR TITLE
Conflict resolution

### DIFF
--- a/include/SGReplicator.h
+++ b/include/SGReplicator.h
@@ -79,11 +79,6 @@ namespace Strata {
             kBusy
         };
 
-        enum class ConflictResolutionPolicy {
-            kDefaultBehavior,
-            kResolveToRemoteRevision
-        };
-
         friend std::ostream& operator << (std::ostream& os, const ActivityLevel& activity_level);
 
         /** SGReplicator start.
@@ -126,17 +121,6 @@ namespace Strata {
         * @brief Returns the current replicator configuration
         */
         SGReplicatorConfiguration* getReplicatorConfig();
-
-        /** SGReplicator setConflictResolutionPolicy.
-        * @brief Set the conflict resolution policy for this replicator. This option should be set before the replicator is started.
-        * @param policy The desired conflict resolution policy.
-        */
-        void setConflictResolutionPolicy(const ConflictResolutionPolicy &policy);
-
-        /** SGReplicator getConflictResolutionPolicy.
-        * @brief Returns the current conflict resolution policy for this replicator.
-        */
-        ConflictResolutionPolicy getConflictResolutionPolicy();
       
     private:
         C4Replicator *c4replicator_{nullptr};
@@ -144,7 +128,6 @@ namespace Strata {
         C4ReplicatorParameters replicator_parameters_;
         C4Error c4error_ {};
         std::mutex replicator_lock_;
-        ConflictResolutionPolicy policy_ = ConflictResolutionPolicy::kDefaultBehavior;
 
         std::function<void(SGReplicator::ActivityLevel, SGReplicatorProgress progress)> on_status_changed_callback_;
         std::function<void(bool pushing, std::string doc_id, std::string error_message, bool is_error,

--- a/include/SGReplicator.h
+++ b/include/SGReplicator.h
@@ -77,6 +77,11 @@ namespace Strata {
             kBusy
         };
 
+        enum class ConflictResolutionPolicy {
+            kDefaultBehavior,
+            kResolveToRemoteRevision
+        };
+
         friend std::ostream& operator << (std::ostream& os, const ActivityLevel& activity_level);
 
         /** SGReplicator start.
@@ -110,9 +115,21 @@ namespace Strata {
         void addValidationListener(
                 const std::function<void(const std::string &doc_id, const std::string &json_body)> &callback);
 
-        SGReplicatorConfiguration* getReplicatorConfig() {
-            return replicator_configuration_;
-        }
+        /** SGReplicator getReplicatorConfig.
+        * @brief Returns the current replicator configuration
+        */
+        SGReplicatorConfiguration* getReplicatorConfig();
+
+        /** SGReplicator setConflictResolutionPolicy.
+        * @brief Set the conflict resolution policy for this replicator.
+        * @param policy The desired conflict resolution policy.
+        */
+        void setConflictResolutionPolicy(const ConflictResolutionPolicy &policy);
+
+        /** SGReplicator getConflictResolutionPolicy.
+        * @brief Returns the current conflict resolution policy for this replicator.
+        */
+        ConflictResolutionPolicy getConflictResolutionPolicy();
 
     private:
         C4Replicator *c4replicator_{nullptr};
@@ -120,6 +137,8 @@ namespace Strata {
         C4ReplicatorParameters replicator_parameters_;
         C4Error c4error_ {};
         std::mutex replicator_lock_;
+        ConflictResolutionPolicy policy_ = ConflictResolutionPolicy::kDefaultBehavior;
+
         std::function<void(SGReplicator::ActivityLevel, SGReplicatorProgress progress)> on_status_changed_callback_;
         std::function<void(bool pushing, std::string doc_id, std::string error_message, bool is_error,
                            bool error_is_transient)> on_document_error_callback_;

--- a/include/SGReplicator.h
+++ b/include/SGReplicator.h
@@ -110,6 +110,9 @@ namespace Strata {
         void addValidationListener(
                 const std::function<void(const std::string &doc_id, const std::string &json_body)> &callback);
 
+        SGReplicatorConfiguration* getReplicatorConfig() {
+            return replicator_configuration_;
+        }
 
     private:
         C4Replicator *c4replicator_{nullptr};

--- a/include/SGReplicator.h
+++ b/include/SGReplicator.h
@@ -121,7 +121,7 @@ namespace Strata {
         SGReplicatorConfiguration* getReplicatorConfig();
 
         /** SGReplicator setConflictResolutionPolicy.
-        * @brief Set the conflict resolution policy for this replicator.
+        * @brief Set the conflict resolution policy for this replicator. This option should be set before the replicator is started.
         * @param policy The desired conflict resolution policy.
         */
         void setConflictResolutionPolicy(const ConflictResolutionPolicy &policy);

--- a/include/SGReplicatorConfiguration.h
+++ b/include/SGReplicatorConfiguration.h
@@ -49,6 +49,11 @@ namespace Strata {
             kPull
         };
 
+        enum class ConflictResolutionPolicy {
+            kDefaultBehavior,
+            kResolveToRemoteRevision
+        };
+
         friend std::ostream& operator << (std::ostream& os, const ReplicatorType& rep_type);
 
         SGDatabase *getDatabase() const;
@@ -79,6 +84,17 @@ namespace Strata {
         */
         bool isValid() const;
 
+        /** SGReplicator setConflictResolutionPolicy.
+        * @brief Set the conflict resolution policy for this replicator. This option should be set before the replicator is started.
+        * @param policy The desired conflict resolution policy.
+        */
+        void setConflictResolutionPolicy(const ConflictResolutionPolicy &policy);
+
+        /** SGReplicator getConflictResolutionPolicy.
+        * @brief Returns the current conflict resolution policy for this replicator.
+        */
+        ConflictResolutionPolicy getConflictResolutionPolicy();
+
     private:
         SGDatabase *database_{nullptr};
         SGAuthenticator *authenticator_{nullptr};
@@ -89,12 +105,15 @@ namespace Strata {
 
         std::vector<std::string> channels_;
 
-        //Holds all extra configuration for the replicator
+        // Holds all extra configuration for the replicator
         fleece::Retained<fleece::impl::MutableDict> options_;
 
         // Options for the replicator progress level
         const int kNotifyOnEveryDocumentChange = 1;
         const int kNotifyOnEveryAttachmentChange = 2;
+
+        // Conflict resolution policy
+        ConflictResolutionPolicy policy_ = ConflictResolutionPolicy::kDefaultBehavior;
     };
 }
 

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -34,12 +34,6 @@ using namespace fleece;
 using namespace fleece::impl;
 #define DEBUG(...) printf("SGReplicator: "); printf(__VA_ARGS__)
 
-
-
-//////////////
-#include <iostream>
-#include "SGMutableDocument.h"
-
 namespace Strata {
     SGReplicator::SGReplicator() {
         replicator_parameters_.callbackContext = this;

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -101,15 +101,15 @@ namespace Strata {
         if(on_status_changed_callback_ == nullptr){
             addChangeListener([](SGReplicator::ActivityLevel, SGReplicatorProgress progress){
                 // placeholder to make sure replicator_parameters_.onStatusChanged has a callback.
-                // The onStatusChanged needs to run regardless if addChangeListener listener used by the application or not.
+                // The onStatusChanged needs to run regardless if addChangeListener is used by the application or not.
             });
         }
 
-        if(on_document_error_callback_ == nullptr && policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
+        if(policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
             addDocumentEndedListener([](bool pushing, std::string doc_id, std::string error_message, bool is_error,
                                      bool error_is_transient){
-                // placeholder to make sure replicator_parameters_.onStatusChanged has a callback.
-                // The onStatusChanged needs to run regardless if addChangeListener listener used by the application or not.
+                // placeholder to make sure replicator_parameters_.onDocumentEnded has a callback if the "ResolveToRemoteRevision" policy is selected.
+                // If the "ResolveToRemoteRevision" policy is selected, onDocumentEnded needs to run regardless if addDocumentEndedListener is used by the application or not.
             });
         }
 

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -108,7 +108,10 @@ namespace Strata {
             });
         }
 
-        if(policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
+        // if(policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
+        if(on_document_error_callback_ == nullptr &&
+        //    policy_ == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
+            replicator_configuration_->getConflictResolutionPolicy() == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
             addDocumentEndedListener([](bool pushing, std::string doc_id, std::string error_message, bool is_error,
                                      bool error_is_transient){
                 // placeholder to make sure replicator_parameters_.onDocumentEnded has a callback if the "ResolveToRemoteRevision" policy is selected.
@@ -215,7 +218,8 @@ namespace Strata {
                                                     bool errorIsTransient,
                                                     void *context) {
 
-            if(flags == kRevIsConflict && ((SGReplicator *) context)->getConflictResolutionPolicy() == ConflictResolutionPolicy::kResolveToRemoteRevision) {
+            if(flags == kRevIsConflict && 
+            ((SGReplicator *) context)->getReplicatorConfig()->getConflictResolutionPolicy() == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
                 C4Database* db = ((SGReplicator *) context)->getReplicatorConfig()->getDatabase()->getC4db();
                 C4Error c4error;
 
@@ -232,12 +236,12 @@ namespace Strata {
                     return;
                 }
 
-                // Revision to keep and revision to discard are the same, so nothing to be done 
+                // Revision to keep and revision to discard are the same, so nothing to be done
                 if(slice(revID) == slice(doc->revID)) {
                     return;
                 }
 
-                if(!c4doc_resolveConflict(doc, revID, doc->revID, nullslice, flags, &c4error)) {    
+                if(!c4doc_resolveConflict(doc, revID, doc->revID, nullslice, flags, &c4error)) {
                     logC4Error(c4error);
                     DEBUG("c4doc_resolveConflict Error\n");
                     return;
@@ -290,13 +294,5 @@ namespace Strata {
 
     SGReplicatorConfiguration* SGReplicator::getReplicatorConfig() {
         return replicator_configuration_;
-    }
-
-    void SGReplicator::setConflictResolutionPolicy(const ConflictResolutionPolicy &policy) {
-        policy_ = policy;
-    }
-
-    SGReplicator::ConflictResolutionPolicy SGReplicator::getConflictResolutionPolicy() {
-        return policy_;
     }
 }

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -52,6 +52,8 @@ namespace Strata {
 
     SGReplicator::~SGReplicator() {
         stop();
+        c4repl_free(c4replicator_);
+        c4replicator_ = nullptr;
     }
 
     SGReplicator::SGReplicator(SGReplicatorConfiguration *replicator_configuration): SGReplicator() {
@@ -64,7 +66,6 @@ namespace Strata {
         if(c4replicator_ != nullptr){
             internal_status_ = Strata::SGReplicatorInternalStatus::kStopping;
             c4repl_stop(c4replicator_);
-            c4repl_free(c4replicator_);
         }
     }
 
@@ -254,7 +255,7 @@ namespace Strata {
                     return;
                 }
 
-                DEBUG("Resolved conflict in document %s to the remote revision.\n", slice(docID).asString().c_str());
+                DEBUG("Resolved conflict in document '%s' to the remote revision.\n", slice(docID).asString().c_str());
             }
 
             alloc_slice error_message = c4error_getDescription(error);

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -108,10 +108,8 @@ namespace Strata {
             });
         }
 
-        // if(policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
         if(on_document_error_callback_ == nullptr &&
-        //    policy_ == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
-            replicator_configuration_->getConflictResolutionPolicy() == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
+        replicator_configuration_->getConflictResolutionPolicy() == SGReplicatorConfiguration::ConflictResolutionPolicy::kResolveToRemoteRevision) {
             addDocumentEndedListener([](bool pushing, std::string doc_id, std::string error_message, bool is_error,
                                      bool error_is_transient){
                 // placeholder to make sure replicator_parameters_.onDocumentEnded has a callback if the "ResolveToRemoteRevision" policy is selected.

--- a/src/SGReplicator.cpp
+++ b/src/SGReplicator.cpp
@@ -111,8 +111,7 @@ namespace Strata {
             });
         }
 
-        //////// VICTOR
-        if(on_document_error_callback_ == nullptr){
+        if(on_document_error_callback_ == nullptr && policy_ == ConflictResolutionPolicy::kResolveToRemoteRevision) {
             addDocumentEndedListener([](bool pushing, std::string doc_id, std::string error_message, bool is_error,
                                      bool error_is_transient){
                 // placeholder to make sure replicator_parameters_.onStatusChanged has a callback.
@@ -200,56 +199,48 @@ namespace Strata {
                                                     bool errorIsTransient,
                                                     void *context) {
 
-            std::cout << "\n[VICTOR] received document: " << slice(docID).asString() << ", is conflict: " << (flags == kRevIsConflict ? "YES" : "NO") << "\n" << std::endl;
+            if(flags == kRevIsConflict && ((SGReplicator *) context)->getConflictResolutionPolicy() == ConflictResolutionPolicy::kResolveToRemoteRevision) {
+                C4Database* db = ((SGReplicator *) context)->getReplicatorConfig()->getDatabase()->getC4db();
+                C4Error c4error;
 
-            // if a conflict is found, delete local copy of document.
-            if(flags == kRevIsConflict) {
-                auto x = ((SGReplicator *) context)->getReplicatorConfig();
-
-                SGDatabase* sgdb = x->getDatabase(); //->getC4db();
-
-                C4Database* db = sgdb->getC4db();
-
-                SGDocument d(sgdb, slice(docID).asString());
-
-                // sgdb->deleteDocument(&d);
-
-                C4Error c4err;
-
-                // C4Document *doc = c4doc_get(db, docID, 0, &c4err);
-
-                C4Document *doc = d.getC4document();
-
-                if(!doc) {
-                    std::cout << "\nDocument returned nullptr, aborting." << std::endl;
+                if(!c4db_beginTransaction(db, &c4error)) {
+                    logC4Error(c4error);
+                    DEBUG("c4db_beginTransaction Error\n");
                     return;
                 }
-                std::cout << "\nDocument returned valid pointer." << std::endl;
 
-                std::cout << "\nDocument ID afterwards: " << slice(doc->docID).asString() << std::endl;
+                C4Document *doc = c4doc_get(db, slice(docID), true, &c4error);
 
-                if(c4db_beginTransaction(db, &c4err)) std::cout << "\nc4db_beginTransaction returned TRUE"; else std::cout << "\nc4db_beginTransaction returned FALSE";
-                if(c4doc_resolveConflict(doc, revID, doc->revID, nullslice, flags, &c4err)) std::cout << "\nc4doc_resolveConflict returned TRUE"; else std::cout << "\nc4doc_resolveConflict returned FALSE";
-                if(c4doc_save(doc, 200, &c4err)) std::cout << "\nc4doc_save returned TRUE"; else std::cout << "\nc4doc_save returned FALSE";
-                if(c4db_endTransaction(db, true, &c4err)) std::cout << "\nc4db_endTransaction returned TRUE"; else std::cout << "\nc4db_endTransaction returned FALSE";  
+                if(!doc) {
+                    DEBUG("Document returned nullptr, aborting.\n");
+                    return;
+                }
 
-                // if(c4doc_selectRevision(doc, revID, 1, &c4err)) {
-                //     std::cout << "\nSelect revision returned TRUE, saving w/ revID " << slice(revID).asString() << ".\n";
-                //     if(c4db_beginTransaction(db, &c4err)) std::cout << "\nc4db_beginTransaction returned TRUE"; else std::cout << "\nc4db_beginTransaction returned FALSE";
-                //     // if(c4doc_loadRevisionBody(doc, &c4err)) std::cout << "\nc4doc_loadRevisionBody returned TRUE"; else std::cout << "\nc4doc_loadRevisionBody returned FALSE";
-                //     // if(c4doc_save(doc, 200, &c4err)) std::cout << "\nc4doc_save returned TRUE"; else std::cout << "\nc4doc_save returned FALSE";
-                //     // if(c4db_endTransaction(db, true, &c4err)) std::cout << "\nc4db_endTransaction returned TRUE"; else std::cout << "\nc4db_endTransaction returned FALSE";  
+                // Revision to keep and revision to discard are the same, so nothing to be done 
+                if(slice(revID) == slice(doc->revID)) {
+                    return;
+                }
 
+                if(!c4doc_resolveConflict(doc, revID, doc->revID, nullslice, flags, &c4error)) {    
+                    logC4Error(c4error);
+                    DEBUG("c4doc_resolveConflict Error\n");
+                    return;
+                }
 
-                    
-                     
-                // }
-                // else std::cout << "\nSelect revision returned FALSE.\n";
+                if(!c4doc_save(doc, 20, &c4error)) {
+                    logC4Error(c4error);
+                    DEBUG("c4doc_save Error\n");
+                    return;
+                }
 
-                // std::cout << "\nDeleted conflicting document " << slice(docID).asString() << std::endl;
+                if(!c4db_endTransaction(db, true, &c4error)) {
+                    logC4Error(c4error);
+                    DEBUG("c4db_endTransaction Error\n");
+                    return;
+                }
+
+                DEBUG("Resolved conflict in document %s to the remote revision.\n", slice(docID).asString().c_str());
             }
-
-        
 
             alloc_slice error_message = c4error_getDescription(error);
             ((SGReplicator *) context)->on_document_error_callback_(pushing, slice(docID).asString(),
@@ -279,5 +270,17 @@ namespace Strata {
 
     std::ostream& operator << (std::ostream& os, const SGReplicator::ActivityLevel& activity_level){
         return os << static_cast<underlying_type<SGReplicator::ActivityLevel>::type> (activity_level);
+    }
+
+    SGReplicatorConfiguration* SGReplicator::getReplicatorConfig() {
+        return replicator_configuration_;
+    }
+
+    void SGReplicator::setConflictResolutionPolicy(const ConflictResolutionPolicy &policy) {
+        policy_ = policy;
+    }
+
+    SGReplicator::ConflictResolutionPolicy SGReplicator::getConflictResolutionPolicy() {
+        return policy_;
     }
 }

--- a/src/SGReplicatorConfiguration.cpp
+++ b/src/SGReplicatorConfiguration.cpp
@@ -122,4 +122,12 @@ namespace Strata {
     std::ostream& operator << (std::ostream& os, const SGReplicatorConfiguration::ReplicatorType& rep_type){
         return os << static_cast<underlying_type<SGReplicatorConfiguration::ReplicatorType>::type> (rep_type);
     }
+
+    void SGReplicatorConfiguration::setConflictResolutionPolicy(const ConflictResolutionPolicy &policy) {
+        policy_ = policy;
+    }
+
+    SGReplicatorConfiguration::ConflictResolutionPolicy SGReplicatorConfiguration::getConflictResolutionPolicy() {
+        return policy_;
+    }
 }

--- a/src/SGReplicatorConfiguration.cpp
+++ b/src/SGReplicatorConfiguration.cpp
@@ -29,9 +29,6 @@ using namespace fleece;
 using namespace fleece::impl;
 #define DEBUG(...) printf("SGReplicatorConfiguration: "); printf(__VA_ARGS__)
 
-///
-#include <iostream>
-
 namespace Strata {
     SGReplicatorConfiguration::SGReplicatorConfiguration() {
         replicator_type_ = ReplicatorType::kPull;

--- a/src/SGReplicatorConfiguration.cpp
+++ b/src/SGReplicatorConfiguration.cpp
@@ -24,11 +24,13 @@
 
 #include "SGReplicatorConfiguration.h"
 
-
 using namespace std;
 using namespace fleece;
 using namespace fleece::impl;
 #define DEBUG(...) printf("SGReplicatorConfiguration: "); printf(__VA_ARGS__)
+
+///
+#include <iostream>
 
 namespace Strata {
     SGReplicatorConfiguration::SGReplicatorConfiguration() {


### PR DESCRIPTION
This addition to the API allows for the conflicts to be detected and resolved to the remote (server) revision if the "kResolveToRemoteRevision" conflict resolution policy is activated. Otherwise, the default behavior is still the same as before. 