### PR TITLE
replace all printf with proper log macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(vendor)
 set(CB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/couchbase-lite-core")
 
 add_library(${PROJECT_NAME}
+    src/SGLoggingCategories.cpp
     src/SGDatabase.cpp
     src/SGDocument.cpp
     src/SGMutableDocument.cpp

--- a/include/SGLogging.h
+++ b/include/SGLogging.h
@@ -40,25 +40,10 @@
 
 #ifdef SHOW_DATABASE_MESSAGES
 
-#if !defined(QT_NO_DEBUG_OUTPUT)
 #  define qC4Debug(category, FMT, ...) C4LogToAt(category(), kC4LogDebug,   FMT, ## __VA_ARGS__)
-#else
-#  define qC4Debug(category, FMT, ...)
-#endif
-
-#if !defined(QT_NO_INFO_OUTPUT)
 #  define qC4Info(category, FMT, ...) C4LogToAt(category(), kC4LogInfo,   FMT, ## __VA_ARGS__)
-#else
-#  define qC4Info(category, FMT, ...)
-#endif
-
-#if !defined(QT_NO_WARNING_OUTPUT)
 #  define qC4Warning(category, FMT, ...) C4LogToAt(category(), kC4LogWarning,   FMT, ## __VA_ARGS__)
-#else
-#  define qC4Warning(category, FMT, ...)
-#endif
-
-#define qC4Critical(category, FMT, ...) C4LogToAt(category(), kC4LogError,   FMT, ## __VA_ARGS__)
+#  define qC4Critical(category, FMT, ...) C4LogToAt(category(), kC4LogError,   FMT, ## __VA_ARGS__)
 
 #else
 

--- a/include/SGLogging.h
+++ b/include/SGLogging.h
@@ -1,0 +1,72 @@
+//
+//  SGLogging.h
+//
+//  Copyright 2014 ON Semiconductor.
+//  All rights reserved. This software and/or documentation is licensed by ON Semiconductor under
+//  limited terms and conditions. The terms and conditions pertaining to the software and/or documentation are available at
+//  http://www.onsemi.com/site/pdf/ONSEMI_T&C.pdf (“ON Semiconductor Standard Terms and Conditions of Sale, Section 8 Software”).
+//  Do not use this software and/or documentation unless you have carefully read and you agree to the limited terms and conditions.
+//  By using this software and/or documentation, you agree to the limited terms and conditions.
+//
+//  Copyright 2019 ON Semiconductor
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef SGLOGGING_H
+#define SGLOGGING_H
+#include <litecore/c4.h>
+#include <litecore/Logging.hh>
+
+#define Q_DECLARE_C4_LOGGING_CATEGORY(name) \
+    extern C4LogDomain &name();
+
+#define Q_C4_LOGGING_CATEGORY(name, ...) \
+    C4LogDomain &name() \
+    { \
+        static litecore::LogDomain logdomain(__VA_ARGS__, litecore::LogLevel::Debug); \
+        static C4LogDomain c4logdomain = (C4LogDomain)&logdomain; \
+        return c4logdomain; \
+    }
+
+#ifdef SHOW_DATABASE_MESSAGES
+
+#if !defined(QT_NO_DEBUG_OUTPUT)
+#  define qC4Debug(category, FMT, ...) C4LogToAt(category(), kC4LogDebug,   FMT, ## __VA_ARGS__)
+#else
+#  define qC4Debug(category, FMT, ...)
+#endif
+
+#if !defined(QT_NO_INFO_OUTPUT)
+#  define qC4Info(category, FMT, ...) C4LogToAt(category(), kC4LogInfo,   FMT, ## __VA_ARGS__)
+#else
+#  define qC4Info(category, FMT, ...)
+#endif
+
+#if !defined(QT_NO_WARNING_OUTPUT)
+#  define qC4Warning(category, FMT, ...) C4LogToAt(category(), kC4LogWarning,   FMT, ## __VA_ARGS__)
+#else
+#  define qC4Warning(category, FMT, ...)
+#endif
+
+#define qC4Critical(category, FMT, ...) C4LogToAt(category(), kC4LogError,   FMT, ## __VA_ARGS__)
+
+#else
+
+#  define qC4Debug(category, FMT, ...)
+#  define qC4Info(category, FMT, ...)
+#  define qC4Warning(category, FMT, ...)
+#  define qC4Critical(category, FMT, ...)
+
+#endif
+
+#endif //SGLOGGING_H

--- a/include/SGLoggingCategories.h
+++ b/include/SGLoggingCategories.h
@@ -1,5 +1,5 @@
 //
-//  SGUtility.h
+//  SGLoggingC4Categories.h
 //
 //  Copyright 2014 ON Semiconductor.
 //  All rights reserved. This software and/or documentation is licensed by ON Semiconductor under
@@ -22,13 +22,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#ifndef SGUTILITY_H
-#define SGUTILITY_H
-#include <litecore/c4.h>
-#include <string>
+#ifndef SGLOGGINGCATEGORIES_H
+#define SGLOGGINGCATEGORIES_H
+#include "SGLogging.h"
 
 namespace Strata {
-
-    std::string C4ErrorToString(const C4Error &err);
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGDatabase)
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGDocument)
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGMutableDocument)
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGPath)
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGReplicator)
+    Q_DECLARE_C4_LOGGING_CATEGORY(logDomainSGURLEndpoint)
 }
-#endif //SGUTILITY_H
+#endif //SGLOGGINGCATEGORIES_H

--- a/src/SGBasicAuthenticator.cpp
+++ b/src/SGBasicAuthenticator.cpp
@@ -27,12 +27,6 @@
 using namespace fleece;
 using namespace fleece::impl;
 
-#ifdef SHOW_DATABASE_MESSAGES
- #define DEBUG(...) printf("SGBasicAuthenticator: "); printf(__VA_ARGS__)
-#else
- #define DEBUG(...) //
-#endif 
-
 namespace Strata {
     SGBasicAuthenticator::SGBasicAuthenticator() {}
 

--- a/src/SGDocument.cpp
+++ b/src/SGDocument.cpp
@@ -24,15 +24,10 @@
 
 #include <string>
 #include "SGDocument.h"
+#include "SGLoggingCategories.h"
 
 using fleece::impl::Value;
 using namespace std;
-
-#ifdef SHOW_DATABASE_MESSAGES
- #define DEBUG(...) printf("SGDocument: "); printf(__VA_ARGS__)
-#else
- #define DEBUG(...) //
-#endif 
 
 namespace Strata {
     SGDocument::SGDocument() {}
@@ -79,12 +74,12 @@ namespace Strata {
     void SGDocument::initMutableDict() {
         if(exist()) {
             mutable_dict_ = fleece::impl::MutableDict::newDict(Value::fromData(c4document_->selectedRev.body)->asDict());
-            DEBUG("Doc Id: %s, body: %s, revision:%s\n", id_.c_str(), getBody().c_str(), fleece::slice(c4document_->selectedRev.revID).asString().c_str());
+            qC4Debug(logDomainSGDocument, "Doc Id: %s, body: %s, revision:%s", id_.c_str(), getBody().c_str(), fleece::slice(c4document_->selectedRev.revID).asString().c_str());
             return;
         }
         // Init a new mutable dict
         mutable_dict_ = fleece::impl::MutableDict::newDict();
-        DEBUG("c4document_ is null\n");
+        qC4Debug(logDomainSGDocument, "c4document_ is null");
     }
 
     const fleece::impl::Value *SGDocument::get(const std::string &keyToFind) {

--- a/src/SGLoggingCategories.cpp
+++ b/src/SGLoggingCategories.cpp
@@ -1,5 +1,5 @@
 //
-//  SGUtility.h
+//  SGLoggingC4Categories.cpp
 //
 //  Copyright 2014 ON Semiconductor.
 //  All rights reserved. This software and/or documentation is licensed by ON Semiconductor under
@@ -22,13 +22,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#ifndef SGUTILITY_H
-#define SGUTILITY_H
-#include <litecore/c4.h>
-#include <string>
+#include "SGLoggingCategories.h"
 
 namespace Strata {
-
-    std::string C4ErrorToString(const C4Error &err);
+    Q_C4_LOGGING_CATEGORY(logDomainSGDatabase, "SG.database")
+    Q_C4_LOGGING_CATEGORY(logDomainSGDocument, "SG.document")
+    Q_C4_LOGGING_CATEGORY(logDomainSGMutableDocument, "SG.document.mutable")
+    Q_C4_LOGGING_CATEGORY(logDomainSGPath, "SG.path")
+    Q_C4_LOGGING_CATEGORY(logDomainSGReplicator, "SG.replicator")
+    Q_C4_LOGGING_CATEGORY(logDomainSGURLEndpoint, "SG.URLendpoint")
 }
-#endif //SGUTILITY_H

--- a/src/SGMutableDocument.cpp
+++ b/src/SGMutableDocument.cpp
@@ -9,7 +9,8 @@
 * @copyright Copyright 2018 On Semiconductor
 */
 #include "SGMutableDocument.h"
-#define DEBUG(...) printf("SGMutableDocument: "); printf(__VA_ARGS__)
+#include "SGLoggingCategories.h"
+
 namespace Strata {
     SGMutableDocument::SGMutableDocument(class SGDatabase *database, const std::string &docId) : SGDocument(database, docId) {}
 
@@ -17,14 +18,14 @@ namespace Strata {
         try {
             alloc_slice_ = fleece::impl::JSONConverter::convertJSON(body);
             if(!alloc_slice_){
-                DEBUG("Tried to convert invalid json to fleece data: %s\n", body.c_str());
+                qC4Warning(logDomainSGMutableDocument, "Tried to convert invalid json to fleece data: %s", body.c_str());
                 return false;
             }
             mutable_dict_ = fleece::impl::MutableDict::newDict( fleece::impl::Value::fromData(alloc_slice_)->asDict() );
-            DEBUG("Set body: %s\n", mutable_dict_->toJSONString().c_str());
+            qC4Debug(logDomainSGMutableDocument, "Set body: %s", mutable_dict_->toJSONString().c_str());
             return true;
         } catch (const fleece::FleeceException& e) {
-            DEBUG("Fleece error when parsing json to fleece: body:%s - what: %s\n", body.c_str(), e.what());
+            qC4Critical(logDomainSGMutableDocument, "Fleece error when parsing json to fleece: body:%s - what: %s", body.c_str(), e.what());
             return false;
         };
     }

--- a/src/SGPath.cpp
+++ b/src/SGPath.cpp
@@ -23,14 +23,9 @@
 //  limitations under the License.
 
 #include "SGPath.h"
+#include "SGLoggingCategories.h"
 #include <litecore/FilePath.hh>
 #include <litecore/Error.hh>
-
-#ifdef SHOW_DATABASE_MESSAGES
- #define DEBUG(...) printf("SGDocument: "); printf(__VA_ARGS__)
-#else
- #define DEBUG(...) //
-#endif 
 
 using namespace litecore;
 namespace Strata {
@@ -62,11 +57,11 @@ namespace Strata {
         if(!filePath.exists()){
             try{
                 if(!filePath.mkdir()){
-                    DEBUG("Error creating %s directory\n", path_.c_str());
+                    qC4Warning(logDomainSGPath, "Error creating %s directory", path_.c_str());
                     return false;
                 }
             }catch(const litecore::error& err){
-                DEBUG("Something went wrong! %s ... Code:%d\n", err.what(), err.code);
+                qC4Critical(logDomainSGPath, "Something went wrong! %s ... Code:%d", err.what(), err.code);
                 return false;
             }
         }

--- a/src/SGReplicatorConfiguration.cpp
+++ b/src/SGReplicatorConfiguration.cpp
@@ -28,12 +28,6 @@ using namespace std;
 using namespace fleece;
 using namespace fleece::impl;
 
-#ifdef SHOW_DATABASE_MESSAGES
- #define DEBUG(...) printf("SGReplicatorConfiguration: "); printf(__VA_ARGS__)
-#else
- #define DEBUG(...) //
-#endif 
-
 namespace Strata {
     SGReplicatorConfiguration::SGReplicatorConfiguration() {
         replicator_type_ = ReplicatorType::kPull;

--- a/src/SGURLEndpoint.cpp
+++ b/src/SGURLEndpoint.cpp
@@ -23,15 +23,11 @@
 //  limitations under the License.
 
 #include "SGURLEndpoint.h"
+#include "SGLoggingCategories.h"
 #include <fleece/FleeceImpl.hh>
+
 using namespace std;
 using namespace fleece;
-
-#ifdef SHOW_DATABASE_MESSAGES
- #define DEBUG(...) printf("SGURLEndpoint: "); printf(__VA_ARGS__)
-#else
- #define DEBUG(...) //
-#endif 
 
 namespace Strata {
     SGURLEndpoint::SGURLEndpoint() {
@@ -64,7 +60,7 @@ namespace Strata {
             return false;
         }
 
-        DEBUG("c4address_fromURL is valid\n");
+        qC4Debug(logDomainSGURLEndpoint, "c4address_fromURL is valid");
         setHost( slice(c4address_.hostname).asString() );
         // HACK
         setPath( slice(dbname).asString() );

--- a/src/SGUtility.cpp
+++ b/src/SGUtility.cpp
@@ -24,10 +24,12 @@
 
 #include "SGUtility.h"
 #include <fleece/FleeceImpl.hh>
+
 namespace Strata {
 
-    void logC4Error(const C4Error &err){
+    std::string C4ErrorToString(const C4Error &err)
+    {
         fleece::alloc_slice error_message = c4error_getDescription(err);
-        printf("%s -- ", error_message.asString().c_str());
+        return error_message.asString();
     }
 }


### PR DESCRIPTION
CS-816

Description:
The interface has DEBUG macro which is a wrapper around printf, which should be replaced by proper logger API.

Changes:
Replaced DEBUG macro with a proper couchbase logger API available in the core. After the update the related log from the interface are no longer showing up in Qt console and instead are directed to the HCS log file.